### PR TITLE
rpm dep adjustment

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ setup_requires =
     setuptools_scm[toml]
 
 install_requires =
-    cerberus>=1.3.4
+    cerberus>=1.3.2
     httpx>=0.23.0
     munch>=2.5.0
     tqdm>=4.59.0


### PR DESCRIPTION
* adjust minimum version of cerberus dep
* we need the lowest common version between el9, centos, rocky